### PR TITLE
When log a char buff[size] veriable which create on stack, it will may log a invalid variable in write thread.

### DIFF
--- a/NanoLog.hpp
+++ b/NanoLog.hpp
@@ -58,7 +58,7 @@ namespace nanolog
 	template < size_t N >
 	NanoLogLine& operator<<(const char (&arg)[N])
 	{
-	    encode(string_literal_t(arg));
+	    encode(arg);
 	    return *this;
 	}
 


### PR DESCRIPTION
string_literal_t's constructor put the point of arg to m_cs, not a deep copy. when the arg is a veriable create on stack , or has ben changed, it will may log a invalid variable.